### PR TITLE
Add long-term tool usage checks: measurement, timeline, targets, and commercials

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -69,9 +69,14 @@ src: ./slides/14-effort-commercials.md
 ---
 
 ---
-src: ./slides/15-what-i-need-from-amanda.md
+src: ./slides/15-long-term-usage-checks.md
 ---
 
+---
+src: ./slides/16-draft-email.md
+---
+
+---
 src: ./slides/17-risks-mitigations.md
 ---
 

--- a/slides/02-objectives-success-criteria.md
+++ b/slides/02-objectives-success-criteria.md
@@ -2,7 +2,7 @@
 
 ## Business objectives
 
-• 20–30% time saved on 3+ high‑volume workflows per function (measured by time studies).
+• 20–30% efficiency lift on 3+ high‑volume workflows per function (measured via existing KPIs and sampled output reviews; no stopwatch studies).
 • Faster revenue motions: +15% more qualified meetings/week per AE (Sales), +10% reply rate uplift on personalized outbound (Marketing/Sales).
 • Customer outcomes: −20% median first response time (Support), +10% increase in proactive health check touchpoints (CSM).
 • Ops throughput: automate 3 repetitive workflows (e.g., document prep, reconciliations) with ≥95% accuracy in shadow runs.
@@ -12,6 +12,7 @@
 • 80% of target users complete "AI Core" training and pass a short skills check.
 • 5 cross‑function AI Champions established in China with weekly office hours.
 • Central library of 30+ vetted prompts/templates + 10 SOPs integrated into existing tools.
+• Sustained usage validated post‑handoff: WAU targets at +1 month/+1 quarter and a positive "remove it?" signal.
 
 ## Executive‑level win
 

--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -3,7 +3,7 @@
 ## Phase 1 – Discover & Baseline (Weeks 1–2)
 
 • Intake workshops per function (60–90m each) to map top workflows and pain points.
-• Instrument baselines: time studies on 2–3 workflows per function; export current funnel/CS metrics; capture macros/templates in use.
+• Instrument baselines: pull existing system metrics (funnel/CS/ops), capture current macros/templates, and define lightweight telemetry; optional pulse survey for perceived time saved. No stopwatch time studies (to reduce burden/cost).
 • Select 10 pilot candidates using an Impact × Feasibility scorecard.
 • **Deliverable**: Pilot Backlog v1, Measurement Plan, AI Policy & Guardrails (2‑page).
 
@@ -18,5 +18,11 @@
 
 • Productionize best pilots (target 5–7), add monitoring and fallback SOPs.
 • Expand to adjacent workflows; create Run Books and Champion Playbooks.
-• Build Adoption Dashboard (usage, time saved, quality scores).
+• Build Adoption Dashboard (usage, quality scores, funnel/support KPIs).
 • **Deliverable**: AI Wins Digest (Weeks 8 & 12), Final Report, Roadmap for global rollout.
+
+## Optional – Long‑term usage validation (+1w, +1m, +1q)
+
+• Quick check‑ins after the 12‑week program: review usage dashboards and run a 2‑minute pulse survey.
+• Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
+• Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.

--- a/slides/06-measurement-instrumentation.md
+++ b/slides/06-measurement-instrumentation.md
@@ -1,14 +1,16 @@
 # Measurement & Instrumentation
 
-## How we measure
+## How we measure (low‑overhead)
 
-• **Time saved**: before/after stopwatch on standard tasks (n≥10 samples/workflow).
-• **Quality**: manager review rubric (e.g., accuracy, tone, completeness).
-• **Funnel**: CRM fields (reply rate, meetings booked, cycle time).
+• **Sustained adoption**: weekly active users of templates/agents at +1 week, +1 month, +1 quarter; events per user; completion of AI Core.
+• **Quality**: manager review rubric (e.g., accuracy, tone, completeness) on sampled outputs.
+• **Funnel**: CRM fields (reply rate, meetings booked, cycle time) where applicable.
 • **Support**: AHT, FRT, deflection %, reopen rate.
-• **Adoption**: weekly active users of templates/agents, prompts per user, completion of AI Core.
+• **Signal test**: "Can we remove this tool?" litmus with Champions; objections logged as success signal.
+• **Optional**: 2‑minute pulse survey on perceived time saved and confidence (no stopwatch studies).
 
 ## Dashboards
 
-• Function KPIs (tiles) + "time saved equivalent FTE" + adoption line chart + list of shipped assets.
+• Function KPIs (tiles) + adoption/retention cohort chart + list of shipped assets.
 • A weekly Top 5 Wins tile (with short Loom clips) for Amanda's updates.
+• Simple check‑in view highlighting +1w/+1m/+1q usage and quality trends.

--- a/slides/12-example-metrics-targets.md
+++ b/slides/12-example-metrics-targets.md
@@ -19,3 +19,9 @@
 ## Support
 
 −20% first response time; +10–15% deflection on top 20 FAQs.
+
+## Sustained usage (post‑handoff)
+
+• WAU ≥ 60% of trained users at +1 month; ≥ 45–50% at +1 quarter (by workflow/tool).
+• "Remove it?" test: ≥ 70% of Champions/users object to deprecating high‑value tools.
+• Quality holds: rubric average within 5% of Week‑12 baseline at +1 month and +1 quarter.

--- a/slides/13-reporting-artifacts.md
+++ b/slides/13-reporting-artifacts.md
@@ -4,8 +4,10 @@
 
 • Template Library (≥30 prompts/templates) and Playbooks (10 SOPs).
 • Adoption & Impact Dashboard (Power BI).
-• Pilot Scorecards and Before/After time studies.
+• Pilot Scorecards and before/after metric snapshots (no stopwatch studies).
+• Long‑term Usage Check Kit: pulse survey, "remove it?" script, check‑in runbook, and dashboard view.
 
 ## Handover
 
 Champion Playbook, maintenance plan, backlog for the next 90 days.
+• If opted in: +1m and +1q follow‑up briefs with usage/quality retention and recommendations.

--- a/slides/14-effort-commercials.md
+++ b/slides/14-effort-commercials.md
@@ -20,4 +20,11 @@ _Replace rates with your pricing. These are hour ranges that map cleanly to scop
 • **Effort**: ~260–320 hours.
 • **Fee**: your rate × hours (e.g., $52–64k @ $200/h).
 
+## Optional add‑on – Long‑term usage checks (+1w, +1m, +1q)
+
+• **Scope**: check‑ins post‑handoff; review dashboards, run 2‑minute pulse survey, and "remove it?" signal test; short retention brief with recommendations.
+• **Commercials**: choose one of:
+  – Flat add‑on: $3k–$7k depending on # of workflows/functions.
+  – Outcome‑tied option: $30k for the first 12 weeks, plus a $5k success bonus if tools are still in active use at the agreed check‑in (e.g., +1 month and +1 quarter) by defined thresholds.
+
 **Client time ask (per week)**: Function lead 1–2h, Champion 2–3h, ICs 30–60m, Amanda 30m.

--- a/slides/15-long-term-usage-checks.md
+++ b/slides/15-long-term-usage-checks.md
@@ -1,0 +1,22 @@
+# Long‑Term Usage Checks (opt‑in)
+
+## Why
+
+Sustained adoption matters more than short‑term speedups. We keep measurement light‑touch and focused on signals that are easy to capture.
+
+## What we check (+1w, +1m, +1q)
+
+• Usage: WAU and events/user for shipped templates/agents by function.
+• Quality: spot‑check rubric vs. Week‑12 baseline.
+• Signal test: ask "can we remove this tool?" — track objections as success evidence.
+• 2‑minute pulse: perceived time saved and confidence.
+
+## How it works
+
+• We enable telemetry and dashboards during the 12‑week program.
+• Post‑handoff, we run quick check‑ins and share a one‑page retention brief per window.
+• Findings inform the rollout roadmap and playbook updates.
+
+## Commercials
+
+Flat add‑on ($3k–$7k) or outcome‑tied option: $30k for 12 weeks + $5k success bonus if sustained usage thresholds are met at the agreed check‑in(s).


### PR DESCRIPTION
Summary
- Restructured the project content to accommodate low-overhead, long-term tool usage verification and optional post-engagement check-ins.

Key changes
- Measurement & Instrumentation: removed invasive stopwatch time studies; added sustained adoption metrics (+1w, +1m, +1q), a simple “remove it?” litmus test, and an optional 2-minute pulse survey.
- Workplan & Timeline: introduced an Optional phase for long-term usage validation with scheduled check-ins after Week 12.
- Objectives & Success Criteria: updated to reflect efficiency measurement without stopwatch studies and added sustained usage validation.
- Example Metrics Targets: added sustained usage targets and quality hold thresholds post-handoff.
- Reporting & Artifacts: added a Long-term Usage Check Kit and clarified deliverables (no stopwatch studies); included optional follow-up briefs.
- Effort & Commercials: added an optional add-on for long-term usage checks and included an outcome-tied pricing option ($30k for 12 weeks + $5k success bonus when sustained usage is confirmed).
- Slides: added a new slide (15-long-term-usage-checks.md) and updated slides.md to include it and fix missing references.

Files touched
- slides/02-objectives-success-criteria.md
- slides/05-workplan-timeline.md
- slides/06-measurement-instrumentation.md
- slides/12-example-metrics-targets.md
- slides/13-reporting-artifacts.md
- slides/14-effort-commercials.md
- slides/15-long-term-usage-checks.md (new)
- slides.md (updated order and references)

Why
This aligns the deck with the request to avoid invasive time studies and to measure success by continued tool usage over time, while offering a clear commercial structure to optionally support and validate that usage after the initial 12 weeks.

Closes #1