### PR TITLE
Add introduction slide for Ching & Youngin AI

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -12,6 +12,10 @@ background: ./public/images/alexander-grey-NkQD-RHhbvY-unsplash.jpg
 </div>
 
 ---
+src: ./slides/00-introduction-ching-youngin-ai.md
+---
+
+---
 src: ./slides/01-executive-summary.md
 hide: false
 ---
@@ -81,3 +85,4 @@ src: ./slides/17-risks-mitigations.md
 ---
 
 ---
+

--- a/slides/00-introduction-ching-youngin-ai.md
+++ b/slides/00-introduction-ching-youngin-ai.md
@@ -1,0 +1,27 @@
+# Introduction — Ching & Youngin AI
+
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 32px; align-items: start;">
+  <div>
+    <img src="https://via.placeholder.com/280x280.png?text=Ching" alt="Ching profile photo" width="220" style="border-radius: 12px; box-shadow: 0 8px 24px rgba(0,0,0,0.15); margin-bottom: 18px;" />
+    
+    <h3 style="margin: 0 0 8px;">Ching</h3>
+    <p style="margin: 0 0 10px; color: #555;">Founder & AI Consultant — Youngin AI</p>
+    <ul>
+      <li>AI enterprise developer focused on practical, measurable outcomes</li>
+      <li>7+ years building production AI systems end‑to‑end</li>
+      <li>From discovery and prototyping to deployment and instrumentation</li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 style="margin: 0 0 8px;">Youngin AI</h3>
+    <p style="margin: 0 12px 14px 0;">We are a leading AI enterprise developer. We build AI solutions that ship, stick, and deliver business value.</p>
+    <ul>
+      <li>Building AI solutions since 2018</li>
+      <li>Delivered projects across industries and company sizes</li>
+      <li>Experience ranges from ML models for trend detection to automation & copilots</li>
+      <li>Strong focus on MLOps, data pipelines, governance, and measurable ROI</li>
+    </ul>
+  </div>
+</div>
+


### PR DESCRIPTION
This PR adds a new introduction slide to the deck per the request.

What’s included
- New slide: slides/00-introduction-ching-youngin-ai.md
  - Two-column layout: left for Ching (profile + short bio), right for Youngin AI (company overview)
  - Uses a placeholder profile image URL that can be replaced with a real photo
- slides.md updated to include the new slide right after the title slide and before the Executive Summary

Notes
- The placeholder image can be swapped by placing a profile picture into public/images and updating the img src accordingly.
- Styling is inline and consistent with the existing markdown + HTML approach used in the deck.

Closes #20