### PR TITLE
Replace communications slide with 12-week calendar layout

### DIFF
--- a/slides/11-communications.md
+++ b/slides/11-communications.md
@@ -1,17 +1,22 @@
-# Communications — make Amanda look great
+# 12‑week communications calendar
 
-## Kickoff (Week 1)
+| Week | Mon | Tue | Wed | Thu | Fri |
+|------|-----|-----|-----|-----|-----|
+| 1 | **Kickoff** (program launch) |  |  |  | **Weekly report & demo** (Qing) |
+| 2 |  |  | **1:1s** with dept heads / AI champions (round 1) |  | **Weekly report** (Qing) |
+| 3 |  |  |  |  | **Weekly report** (Qing) |
+| 4 |  |  |  | **EOM executive update** (Qing → wider audience) | **Weekly report** (Qing) |
+| 5 |  |  | **1:1s** follow‑ups |  | **Weekly report** (Qing) |
+| 6 |  |  |  |  | **Weekly report** (Qing) |
+| 7 |  |  |  |  | **Weekly report** (Qing) |
+| 8 |  |  |  | **EOM executive update** (Qing → wider audience) | **Weekly report** (Qing) |
+| 9 |  |  | **1:1s** with champions (round 3) |  | **Weekly report** (Qing) |
+| 10 |  |  |  |  | **Weekly report** (Qing) |
+| 11 |  |  |  |  | **Weekly report** (Qing) |
+| 12 |  |  |  | **EOM update + final readout** | **Weekly report & wrap‑up** (Qing) |
 
-Amanda opens the "AI‑First China Lighthouse."
+Notes
+- Weekly report from Qing every Friday: progress, wins, risks, next week focus; share recordings or GIFs where helpful.
+- End‑of‑month (EOM) executive updates in Weeks 4, 8, and 12 for a wider audience; align on decisions, unblockers, and next phase.
+- Interspersed 1:1s with department heads and AI champions to capture feedback, spot adoption risks, and tune pilots.
 
-## Friday Demos
-
-30–45 minutes; Amanda closes with "what this unlocks."
-
-## AI Wins Digest (Weeks 4/8/12)
-
-1‑page with metrics, GIFs/Looms; Amanda forwards to CEO/CTO + global LT.
-
-## Leadership Readout (Weeks 6 & 12)
-
-30‑minute session led by Amanda; China as the model for global rollout.


### PR DESCRIPTION
This PR replaces the existing Communications slide with a concise 12-week calendar layout to make cadence and key touchpoints crystal clear.

What changed
- Updated slides/11-communications.md to a calendar-style table covering Weeks 1–12
- Highlights:
  - Week 1 Monday kickoff
  - Weekly Friday reports/demos from Qing
  - End-of-month (Weeks 4, 8, 12) executive updates to a wider audience
  - Interspersed 1:1s with department heads and AI champions (Weeks 2, 5, 9)
- Added a short Notes section clarifying intent for each touchpoint

Reasoning
- The issue requested replacing the communications slide with a calendar that clearly shows the 12-week cadence, key dates, and responsibilities. The table format offers a quick visual reference while staying within Slidev/Markdown.

No build or runtime changes required.

Closes #21