### PR TITLE
Replace communications slide with 12-week calendar layout

### DIFF
--- a/slides/11-communications.md
+++ b/slides/11-communications.md
@@ -1,17 +1,97 @@
-# Communications — make Amanda look great
+# 12‑Week Communications Calendar
 
-## Kickoff (Week 1)
+Small, predictable touchpoints that keep momentum and visibility high.
 
-Amanda opens the "AI‑First China Lighthouse."
+<div style="font-size: 12px; margin-bottom: 8px;">
+  Legend: <span style="font-weight:600;">K</span> = Kickoff (Mon) · <span style="font-weight:600;">W</span> = Weekly report from Qing (Fri) · <span style="font-weight:600;">E</span> = Executive update (end of month) · <span style="font-weight:600;">1:1</span> = Department head / AI Champion check‑ins
+</div>
 
-## Friday Demos
+<table style="width:100%; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr>
+      <th style="border-bottom:1px solid #ccc; text-align:left; padding:6px 8px;">Stream</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W1</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W2</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W3</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W4</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W5</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W6</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W7</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W8</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W9</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W10</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W11</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W12</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Program kickoff (Mon)</td>
+      <td style="border-top:1px solid #eee; text-align:center;">K</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Weekly report from Qing (Fri)</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+      <td style="border-top:1px solid #eee; text-align:center;">W</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Executive update (end of month)</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">E</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">E</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">E</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Dept head / AI Champion 1:1s</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">1:1</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+  </tbody>
+</table>
 
-30–45 minutes; Amanda closes with "what this unlocks."
+## Notes
 
-## AI Wins Digest (Weeks 4/8/12)
+- Kickoff on Monday of Week 1 to set goals, roles, and norms.
+- Weekly Friday report from Qing goes to project team plus Amanda; include wins, blockers, next week plan.
+- End‑of‑month executive update (Weeks 4/8/12) with Qing + broader leadership for visibility and decisions.
+- 1:1s staggered with department heads and AI Champions to unblock pilots and drive adoption.
 
-1‑page with metrics, GIFs/Looms; Amanda forwards to CEO/CTO + global LT.
-
-## Leadership Readout (Weeks 6 & 12)
-
-30‑minute session led by Amanda; China as the model for global rollout.


### PR DESCRIPTION
This PR replaces the previous communications slide with a clear 12-week calendar layout, per the request.

What changed
- Rewrote slides/11-communications.md to present a 12-week communications calendar.
- Included a compact grid highlighting:
  - Kickoff on Monday of Week 1
  - Weekly Friday reports from Qing (Weeks 1–12)
  - End-of-month executive updates (Weeks 4, 8, 12)
  - Interspersed 1:1s with department heads and AI Champions
- Added a concise legend and notes to clarify cadence and audiences.

Why
- Provides an at-a-glance view of cadence and key touchpoints across the 12-week program.
- Aligns with the request to replace the generic communications slide with a concrete calendar.

Screens/Preview
- Render via `pnpm dev` and navigate to the Communications slide to see the calendar table.

Let me know if you’d like additional callouts (e.g., dates instead of week numbers, or color-coding for audiences).

Closes #21