### PR TITLE
Revise RASI slide to focus on required resources; move cadence to timeline

### DIFF
--- a/slides/04-operating-model-roles.md
+++ b/slides/04-operating-model-roles.md
@@ -1,14 +1,8 @@
-# Operating Model & Roles (RACI)
+# Operating Model & Required Resources
 
-## Roles
+## Required resources
 
-• **Sponsor**: Amanda (sets goals, unblocks resources, hosts monthly exec update).
-• **Engagement Lead / AI Consultant**: Ching (designs curriculum, runs discovery, builds pilots, defines metrics, owns Friday demos).
-• **Function Leads** (Sales, Marketing, CSM, Ops, Support): nominate 1 AI Champion each; provide processes, sample data, and sign‑off.
-• **IT/Data/Legal**: tool access, SSO, data policy review, retention.
+• AI Consultant: Ching — designs curriculum, runs discovery, builds pilots, defines metrics, and hosts Friday demos.
+• Functional Leads — one per department (Sales, Marketing, CSM, Ops, Support) serving as AI Champions; provide processes, sample data, and sign‑off.
+• IT / Data / Legal — provision tools and access (SSO), review data policy and retention, ensure compliance.
 
-## Cadence
-
-• **Weekly**: Mon planning (30m), Tue/Thu build, Fri demo (30–45m).
-• **Biweekly**: Champion Clinic (90m), adoption/metrics review (30m).
-• **Monthly**: Exec Readout (30m) led by Amanda.

--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -1,5 +1,11 @@
 # Workplan & Timeline (12 weeks)
 
+## Cadence
+
+• Weekly: Mon planning (30m), Tue/Thu build, Fri demo (30–45m).
+• Biweekly: Champion Clinic (90m), adoption/metrics review (30m).
+• Monthly: Exec Readout (30m) led by Amanda.
+
 ## Phase 1 – Discover & Baseline (Weeks 1–2)
 
 • Intake workshops per function (60–90m each) to map top workflows and pain points.
@@ -26,3 +32,4 @@
 • Quick check‑ins after the 12‑week program: review usage dashboards and run a 2‑minute pulse survey.
 • Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
 • Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.
+


### PR DESCRIPTION
This PR addresses the request to revise the RASI slide to focus on required resources and to relocate cadence details to the timeline.

Changes:
- Slide 04: Renamed to “Operating Model & Required Resources,” removed RACI framing and sponsor role. Focused on required resources:
  - AI Consultant: Ching
  - Functional Leads (one per department as AI Champions)
  - IT / Data / Legal support
- Slide 04: Removed cadence section to avoid duplication and align with new focus.
- Slide 05: Added a Cadence section at the top of the Workplan & Timeline slide, capturing weekly, biweekly, and monthly rhythms.

Rationale:
- Aligns with the directive to emphasize resources needed rather than role assignment matrices.
- Places cadence where it best complements planning (timeline slide).

Let me know if you’d like to further refine language (e.g., include/exclude specific departments) or reintroduce the sponsor in a separate executive engagement note.

Closes #9