### PR TITLE
Reorganize Workplan & Timeline slide to prevent content cutoff and fix bullet formatting

### DIFF
--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -2,27 +2,40 @@
 
 ## Phase 1 – Discover & Baseline (Weeks 1–2)
 
-• Intake workshops per function (60–90m each) to map top workflows and pain points.
-• Instrument baselines: pull existing system metrics (funnel/CS/ops), capture current macros/templates, and define lightweight telemetry; optional pulse survey for perceived time saved. No stopwatch time studies (to reduce burden/cost).
-• Select 10 pilot candidates using an Impact × Feasibility scorecard.
-• **Deliverable**: Pilot Backlog v1, Measurement Plan, AI Policy & Guardrails (2‑page).
+- Intake workshops per function (60–90m each) to map top workflows and pain points.
+- Instrument baselines: pull existing system metrics (funnel/CS/ops), capture current macros/templates, and define lightweight telemetry; optional pulse survey for perceived time saved. No stopwatch time studies (to reduce burden/cost).
+- Select 10 pilot candidates using an Impact × Feasibility scorecard.
+- **Deliverable**: Pilot Backlog v1, Measurement Plan, AI Policy & Guardrails (2‑page).
+
+---
+
+# Workplan & Timeline (12 weeks)
 
 ## Phase 2 – Train & Prototype (Weeks 3–6)
 
-• AI Core (2 x 90m) for all participants: prompt patterns, critique loops, verification, retrieval, and safe data use.
-• Function Labs (2 x 60m) per team with hands‑on assets (templates, checklists).
-• Build 10 pilots in 1‑week sprints (2 per function), with shadow runs in Weeks 4–5 and 3–5 going live by Week 6.
-• **Deliverable**: Friday Demos (recorded), Template Library v1, Pilot scorecards.
+- AI Core (2 x 90m) for all participants: prompt patterns, critique loops, verification, retrieval, and safe data use.
+- Function Labs (2 x 60m) per team with hands‑on assets (templates, checklists).
+- Build 10 pilots in 1‑week sprints (2 per function), with shadow runs in Weeks 4–5 and 3–5 going live by Week 6.
+- **Deliverable**: Friday Demos (recorded), Template Library v1, Pilot scorecards.
+
+---
+
+# Workplan & Timeline (12 weeks)
 
 ## Phase 3 – Deploy, Scale, Handoff (Weeks 7–12)
 
-• Productionize best pilots (target 5–7), add monitoring and fallback SOPs.
-• Expand to adjacent workflows; create Run Books and Champion Playbooks.
-• Build Adoption Dashboard (usage, quality scores, funnel/support KPIs).
-• **Deliverable**: AI Wins Digest (Weeks 8 & 12), Final Report, Roadmap for global rollout.
+- Productionize best pilots (target 5–7), add monitoring and fallback SOPs.
+- Expand to adjacent workflows; create Run Books and Champion Playbooks.
+- Build Adoption Dashboard (usage, quality scores, funnel/support KPIs).
+- **Deliverable**: AI Wins Digest (Weeks 8 & 12), Final Report, Roadmap for global rollout.
+
+---
+
+# Workplan & Timeline (12 weeks)
 
 ## Optional – Long‑term usage validation (+1w, +1m, +1q)
 
-• Quick check‑ins after the 12‑week program: review usage dashboards and run a 2‑minute pulse survey.
-• Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
-• Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.
+- Quick check‑ins after the 12‑week program: review usage dashboards and run a 2‑minute pulse survey.
+- Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
+- Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.
+


### PR DESCRIPTION
Problem
- On the Workplan & Timeline slide, content past Phase 2 was cut off due to too much vertical content on a single landscape slide.
- Bullet points used a custom bullet character (•) which wasn’t rendered as proper list items in Markdown, causing bullets to flow on the same line and hurt readability.

What changed
- Split the Workplan & Timeline content into four slides (Phase 1, Phase 2, Phase 3, Optional) using Slidev slide breaks (---) to ensure nothing gets cut off.
- Converted custom bullets (•) to proper Markdown list items (-) so each point starts on a new line with consistent spacing.

Files updated
- slides/05-workplan-timeline.md

Impact
- All content is now visible within the slide boundaries.
- Bullet points render correctly as lists, improving readability.

Notes
- No functional code changes or new dependencies; only Markdown restructuring.
- Slide titles were kept consistent across the split slides for continuity.

Closes #13