### PR TITLE
Add scheduled 1-hour department lead interviews to timeline and operating model

### DIFF
--- a/slides/04-operating-model-roles.md
+++ b/slides/04-operating-model-roles.md
@@ -3,5 +3,6 @@
 ## Required resources
 
 - AI Consultant: Ching — designs curriculum, runs discovery, builds pilots, defines metrics, and hosts Friday demos.
-- Functional Leads — one per department (Sales, Marketing, CSM, Ops, Support) serving as AI Champions; provide processes, sample data, and sign‑off.
+- Functional Leads — one per department (Sales, Marketing, CSM, Ops, Support) serving as AI Champions; provide processes, sample data, and sign‑off, and commit to a 60‑minute discovery interview with Ching in Weeks 1–2.
 - IT / Data / Legal — provision tools and access (SSO), review data policy and retention, ensure compliance.
+

--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -9,7 +9,8 @@
 ## Phase 1 – Discover & Baseline (Weeks 1–2)
 
 - Intake workshops per function (60–90m each) to map top workflows and pain points.
-- At least five (5) 60‑minute stakeholder interviews to document current ("as‑is") business flows; synthesize notes and opportunities.
+- One 60‑minute interview per department lead (Sales, Marketing, CSM, Ops, Support) with Ching to walk through current processes, dependencies, and where AI could help; schedule at least 1 hour per department.
+- Additional stakeholder interviews as needed (≥5 total) to document current ("as‑is") business flows; synthesize notes and opportunities.
 - Instrument baselines: pull existing system metrics (funnel/CS/ops), capture current macros/templates, and define lightweight telemetry; optional pulse survey for perceived time saved. No stopwatch time studies (to reduce burden/cost).
 - Select 10 pilot candidates through facilitated impact × feasibility prioritization (no formal scorecard deliverable).
 - **Deliverable**: Pilot Backlog v1, Measurement Plan, AI Policy & Guardrails (2‑page).
@@ -45,3 +46,4 @@
 - Quick check‑ins after the 12‑week program: review usage reports and run a 2‑minute pulse survey.
 - Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
 - Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.
+


### PR DESCRIPTION
This PR addresses the issue to schedule department interviews for AI workflow assessment.

Key updates:
- Timeline (Phase 1 – Discover & Baseline): Added an explicit bullet to schedule one 60-minute interview per department lead (Sales, Marketing, CSM, Ops, Support) with Ching to capture processes and AI opportunities. Clarified that additional stakeholder interviews (≥5 total) may be conducted as needed.
- Operating Model & Required Resources: Updated the Functional Leads line to include a commitment to a 60-minute discovery interview with Ching in Weeks 1–2.

Rationale:
- Makes the per-department interview requirement explicit and scheduled within Weeks 1–2, ensuring adequate discovery depth for workflow optimization.
- Keeps changes minimal and consistent with existing slide style and cadence.

No build or dependency changes required; content-only update.

Closes #11