### PR TITLE
Revise slide 10 to focus on Change Management using ADKAR lens

### DIFF
--- a/slides/10-governance-risk-change-mgmt.md
+++ b/slides/10-governance-risk-change-mgmt.md
@@ -1,9 +1,9 @@
 ---
-layout: two-cols
+layout: three-cols
 ---
 
 ::header::
-# Change Management (ADKAR lens)
+# We employ change management best practices (ADKAR) to ensure greatest adoption and impact.
 
 ::default::
 
@@ -15,6 +15,7 @@ layout: two-cols
 - Ability — people can do it in their real work (guided practice, coaching, SOPs).
 - Reinforcement — change sticks (feedback loops, metrics, stories, incentives).
 
+::middle::
 ## How we drive it in this program
 
 - Awareness: Program kickoff + Executive Summary set the case for change; guardrails keep it safe.

--- a/slides/10-governance-risk-change-mgmt.md
+++ b/slides/10-governance-risk-change-mgmt.md
@@ -1,17 +1,36 @@
-# Governance, Risk & Change Mgmt
+---
+layout: two-cols
+---
 
-## Policy
+::header::
+# Change Management (ADKAR lens)
 
-2‑page "AI Acceptable Use" (red/yellow/green data, review thresholds, approval steps).
+::default::
 
-## Human‑in‑the‑loop
+## What the ADKAR lens looks like
 
-External comms and legal/compliance outputs always require human sign‑off.
+- Awareness — people understand why we’re changing now (business case, risks of status quo).
+- Desire — people want to participate (clear WIIFM, visible quick wins, recognition).
+- Knowledge — people know what to do (training, examples, job aids).
+- Ability — people can do it in their real work (guided practice, coaching, SOPs).
+- Reinforcement — change sticks (feedback loops, metrics, stories, incentives).
 
-## Quality gates
+## How we drive it in this program
 
-Spot‑check 5% of AI‑assisted outputs; failure → revert & fix template.
+- Awareness: Program kickoff + Executive Summary set the case for change; guardrails keep it safe.
+- Desire: Quick‑win pilots and weekly demos highlight value; celebrate contributions.
+- Knowledge: AI Core + Function Labs deliver practical skills with 1‑pagers and Looms.
+- Ability: Shadow runs, Clinics/office hours, and run books help teams perform on the job.
+- Reinforcement: Wins Digest, simple usage snapshots, and Champion Playbooks sustain momentum.
 
-## Change mgmt
+::right::
+## Ties to our project structure
 
-ADKAR lens—awareness (kickoff), desire (quick wins), knowledge/ability (labs + clinics), reinforcement (leaderboard, recognition).
+- 01 Executive Summary → Awareness
+- 05 Workplan (Phases 1–3) → Desire, Ability via quick wins, shadow runs, go‑lives
+- 07 Training & Enablement → Knowledge (AI Core, Function Labs, job aids)
+- 08 Candidate Pilot Backlog → Desire via visible, valuable use cases
+- 11 Communications (12‑week calendar) → Awareness, Reinforcement
+- 13 Reporting & Deliverables → Reinforcement (usage highlights, playbooks)
+- 15 Long‑Term Usage Checks (opt‑in) → Reinforcement (retention signals)
+


### PR DESCRIPTION
This PR updates slide 10 to concentrate solely on change management, per the request.

Key changes:
- Replaced the previous "Governance, Risk & Change Mgmt" content with a focused "Change Management (ADKAR lens)" slide.
- Spelled out the ADKAR model (Awareness, Desire, Knowledge, Ability, Reinforcement) and briefly described each component.
- Added a concise mapping from each ADKAR element to our project structure (Executive Summary, Workplan & Timeline, Training & Enablement, Pilot Backlog, Communications, Reporting, and Long‑Term Usage Checks).
- Adopted a two-column layout for clarity: left = what the lens looks like + how we drive it; right = ties to project structure.

Outcome:
- A clearer, actionable change‑management slide that aligns directly with the rest of the deck and highlights how adoption will be achieved and sustained.

Closes #19