### PR TITLE
Update objectives slide to show suggested targets with ranges

### DIFF
--- a/slides/02-objectives-success-criteria.md
+++ b/slides/02-objectives-success-criteria.md
@@ -3,28 +3,29 @@ layout: three-cols
 ---
 
 ::header::
-# Objectives & Success Criteria
+# Suggested objectives & success criteria
 
 ::default::
 
 ## Business objectives
 
-- 20-30% efficiency lift on 3+ high‑volume workflows per function (measured via existing KPIs and sampled output reviews; no stopwatch studies).
-- Faster revenue motions: +15% more qualified meetings/week per AE (Sales), +10% reply rate uplift on personalized outbound (Marketing/Sales).
-- Customer outcomes: −20% median first response time (Support), +10% increase in proactive health check touchpoints (CSM).
-- Ops throughput: automate 3 repetitive workflows (e.g., document prep, reconciliations) with ≥95% accuracy in shadow runs.
+- Aim for efficiency lift on high‑volume workflows per function (ballpark: 15–30% across 2–4 workflows; measured via existing KPIs and sampled output reviews—no stopwatch studies).
+- Faster revenue motions: focus on pipeline velocity (e.g., +10–20% more qualified meetings/week per AE; +5–15% reply‑rate uplift on personalized outbound for Marketing/Sales).
+- Customer outcomes: improve responsiveness and proactive touchpoints (e.g., −10–25% median first‑response time in Support; +5–15% increase in proactive health checks for CSM).
+- Ops throughput: automate repetitive workflows with quality gates (target 2–4 workflows; shadow‑run accuracy ~90–97% before production).
 
 ::middle::
 
 ## Adoption objectives
 
-- 80% of target users complete "AI Core" training and pass a short skills check.
-- 5 cross‑function AI Champions established in China with weekly office hours.
-- Central library of 30+ vetted prompts/templates + 10 SOPs integrated into existing tools.
-- Sustained usage validated post‑handoff: WAU targets at +1 month/+1 quarter and a positive "remove it?" signal.
+- Training completion: majority of target users complete "AI Core" and pass a short skills check (aim for ~70–90%).
+- Community: establish AI Champions with office hours (target 3–6 Champions in China).
+- Reusable assets: central library grows and integrates into existing tools (ballpark: 20–40 vetted prompts/templates and 8–12 SOPs).
+- Sustained usage: validate post‑handoff with WAU targets at +1 month/+1 quarter (e.g., 20–40% at +1 mo; 30–60% at +1 qtr) and a clear "should we remove it?" no‑signal.
 
 ::right::
 
 ## Executive‑level win
 
-- Monthly "AI Wins" digest and a 30‑minute show‑and‑tell for the global LT by Week 6 highlighting China's results.
+- Monthly "AI Wins" digest and a 30‑minute show‑and‑tell for the global LT (target timing: Week 6–8) highlighting China's results.
+


### PR DESCRIPTION
This PR updates the Objectives & Success Criteria slide to frame goals as suggested targets with ballpark ranges rather than fixed numbers, per the issue request.

Key changes:
- Renamed header to “Suggested objectives & success criteria” to set context.
- Softened language (e.g., “Aim for”, “focus on”) and added parenthetical ranges for each metric.
- Business objectives now include example ranges for efficiency lift, revenue motions, customer outcomes, and ops throughput quality gates.
- Adoption objectives now specify ranges for training completion, AI Champions, reusable assets, and WAU targets.
- Executive-level milestone now indicates a target timing window (Week 6–8).

These adjustments keep the spirit of the original goals while signaling flexibility and allowing teams to calibrate based on baselines.

Closes #5