### PR TITLE
Remove Scope, Assumptions, Guardrails slide from deck

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -25,10 +25,6 @@ src: ./slides/02-objectives-success-criteria.md
 ---
 
 ---
-src: ./slides/03-scope-assumptions-guardrails.md
----
-
----
 src: ./slides/04-operating-model-roles.md
 ---
 


### PR DESCRIPTION
This PR removes the "Scope, Assumptions, Guardrails" slide from the presentation as requested.

Changes:
- Removed the import block for `./slides/03-scope-assumptions-guardrails.md` from `slides.md`, effectively taking the slide out of the deck.

Notes:
- No other slides or references were modified. Textual mentions of "guardrails" on other slides remain, as they are unrelated to the removed slide.
- The source file `slides/03-scope-assumptions-guardrails.md` is no longer referenced by the deck. If you would like the file physically deleted from the repo as well, I can follow up with a cleanup PR or include it here on request.

Closes #8