### PR TITLE
Update deck title to “Upskill Horizon Workforce with AI”

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -3,7 +3,7 @@ theme: seriph
 background: ./images/alexander-grey-NkQD-RHhbvY-unsplash.jpg
 ---
 
-# Horizon (AI)
+# Upskill Horizon Workforce with AI
 
 <div style="position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); display: flex; align-items: center; gap: 20px; z-index: 1000;">
   <img src="https://joinhorizons.com/wp-content/uploads/2024/04/Logo-Horizons-Dark-Transparent-2-1.png" alt="Horizons logo" width="120" />

--- a/slides/01-executive-summary.md
+++ b/slides/01-executive-summary.md
@@ -1,4 +1,4 @@
-# Executive Summary — "AI‑First China Lighthouse"
+# Executive Summary — Upskill Horizon Workforce with AI
 
 We'll run a <span class="keyword highlight">12‑week</span> <span class="keyword">change‑management</span> program across Sales, Marketing, CSM, Operations, and Support in China. The program combines short, high‑leverage <span class="keyword">training</span> with tightly scoped <span class="keyword">pilots</span>, measured against clear <span class="keyword">baseline metrics</span>. Every <span class="keyword">Friday</span> we demo what shipped. By <span class="keyword">Week 6</span> we will have at least <span class="keyword">5 productionized wins</span> and a public <span class="keyword">“AI Wins”</span> digest that can be shared with the global leadership team. By <span class="keyword">Week 12</span> we hand over <span class="keyword">playbooks</span>, <span class="keyword">dashboards</span>, and an internal <span class="keyword">“AI Champion”</span> network so China can scale independently and showcase wins to the global team.
 


### PR DESCRIPTION
This PR updates the presentation to use a clear, direct title aligned with the project’s purpose.

Changes
- Deck title (slides.md) updated from “Horizon (AI)” to “Upskill Horizon Workforce with AI”.
- Executive Summary slide header (slides/01-executive-summary.md) updated to “Executive Summary — Upskill Horizon Workforce with AI”, removing the previous “AI‑First China Lighthouse” label.

Scope
- No other content changes were made to keep the PR small and focused. If you’d like the Executive Summary body to remove the China-specific references as well, I can follow up in a separate PR.

Reasoning
- The issue requested a simple, direct title reflecting the upskilling focus and not referencing the “AI‑First China Lighthouse”.

Please review and let me know if you prefer the variant with the possessive form ("Horizon’s") or any slight wording tweaks.

Closes #37