### PR TITLE
Redesign change management page with color-coded ADKAR pillars

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -53,6 +53,10 @@ src: ./slides/10-governance-risk-change-mgmt.md
 ---
 
 ---
+src: ./slides/10-change-mgmt-adkar-redesign.md
+---
+
+---
 src: ./slides/11-communications.md
 ---
 

--- a/slides/10-change-mgmt-adkar-redesign.md
+++ b/slides/10-change-mgmt-adkar-redesign.md
@@ -1,0 +1,114 @@
+---
+layout: two-cols
+---
+
+::header::
+# Change Management (ADKAR) — color key + activity mapping
+
+::default::
+## ADKAR key
+
+<ul class="adkar-key">
+  <li><span class="adkar-dot awareness"></span> Awareness</li>
+  <li><span class="adkar-dot desire"></span> Desire</li>
+  <li><span class="adkar-dot knowledge"></span> Knowledge</li>
+  <li><span class="adkar-dot ability"></span> Ability</li>
+  <li><span class="adkar-dot reinforcement"></span> Reinforcement</li>
+</ul>
+
+<div class="mt-4 text-sm text-gray-500">
+  Each program activity is tagged with the ADKAR pillar(s) it advances.
+</div>
+
+::right::
+## Program activities mapped to ADKAR
+
+<ul class="adkar-list">
+  <li>
+    <span class="item">Program kickoff</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot awareness" title="Awareness"></span>
+      <span class="adkar-dot desire" title="Desire"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Executive summary</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot awareness" title="Awareness"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Quick‑win pilots</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot desire" title="Desire"></span>
+      <span class="adkar-dot ability" title="Ability"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Weekly demos</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot desire" title="Desire"></span>
+      <span class="adkar-dot awareness" title="Awareness"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">AI Core training</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot knowledge" title="Knowledge"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Function Labs</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot knowledge" title="Knowledge"></span>
+      <span class="adkar-dot ability" title="Ability"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Office hours / Clinics</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot ability" title="Ability"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Shadow runs</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot ability" title="Ability"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Run books / SOPs</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot ability" title="Ability"></span>
+      <span class="adkar-dot reinforcement" title="Reinforcement"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Communications calendar</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot awareness" title="Awareness"></span>
+      <span class="adkar-dot reinforcement" title="Reinforcement"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Wins Digest</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot reinforcement" title="Reinforcement"></span>
+      <span class="adkar-dot desire" title="Desire"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Usage snapshots</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot reinforcement" title="Reinforcement"></span>
+    </span>
+  </li>
+  <li>
+    <span class="item">Champion playbooks</span>
+    <span class="adkar-dots">
+      <span class="adkar-dot reinforcement" title="Reinforcement"></span>
+      <span class="adkar-dot knowledge" title="Knowledge"></span>
+    </span>
+  </li>
+</ul>
+

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,13 @@
   /* Primary accent used across custom elements */
   --horizon-accent: #2563eb; /* blue-600 */
   --horizon-accent-rgb: 37, 99, 235;
+
+  /* ADKAR palette */
+  --adkar-awareness: #f59e0b;     /* amber-500 */
+  --adkar-desire: #ef4444;        /* red-500 */
+  --adkar-knowledge: #6366f1;     /* indigo-500 */
+  --adkar-ability: #10b981;       /* emerald-500 */
+  --adkar-reinforcement: #06b6d4; /* cyan-500 */
 }
 
 /* Emphasize key words inline with a consistent accent */
@@ -47,5 +54,63 @@
     rgba(var(--horizon-accent-rgb), 0.22) 0
   );
   border-radius: 2px;
+}
+
+/* ADKAR visual key + mapping */
+.adkar-key {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.adkar-key li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.adkar-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  display: inline-block;
+  box-shadow: 0 0 0 2px rgba(0,0,0,0.06) inset;
+}
+
+.adkar-dot.awareness { background: var(--adkar-awareness); }
+.adkar-dot.desire { background: var(--adkar-desire); }
+.adkar-dot.knowledge { background: var(--adkar-knowledge); }
+.adkar-dot.ability { background: var(--adkar-ability); }
+.adkar-dot.reinforcement { background: var(--adkar-reinforcement); }
+
+.adkar-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.adkar-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.adkar-list .item {
+  font-weight: 500;
+}
+
+.adkar-dots {
+  display: flex;
+  gap: 8px;
 }
 


### PR DESCRIPTION
This PR introduces a redesigned change management slide that visually maps program activities to the ADKAR framework using a clean color-coded legend.

What’s included:
- New slide: slides/10-change-mgmt-adkar-redesign.md using the two-cols layout.
  - Left: ADKAR color key (Awareness, Desire, Knowledge, Ability, Reinforcement).
  - Right: Program activities list with color dots indicating which ADKAR pillars each activity advances (supports multiple pillars per activity).
- Styles: additions to styles.css for reusable ADKAR colors and dot styles (awareness/desire/knowledge/ability/reinforcement).
- slides.md updated to insert the new slide immediately after the existing change management slide for easy side-by-side comparison. The original slide remains unchanged.

Notes:
- Colors chosen for clarity and accessibility (amber, red, indigo, emerald, cyan) and kept minimal for a modern look.
- The layout keeps the page clean and scannable while making pillar coverage obvious at a glance.

If you prefer alternative colors, labels, or activity mappings, I can quickly adjust the palette or list.

Closes #42