### PR TITLE
Add high‑level strategy slide after Objectives

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -28,6 +28,10 @@ src: ./slides/02-objectives-success-criteria.md
 ---
 
 ---
+src: ./slides/03-high-level-strategy.md
+---
+
+---
 src: ./slides/05-workplan-timeline.md
 ---
 
@@ -70,3 +74,4 @@ src: ./slides/14-effort-commercials.md
 ---
 src: ./slides/15-long-term-usage-checks.md
 ---
+

--- a/slides/03-high-level-strategy.md
+++ b/slides/03-high-level-strategy.md
@@ -1,0 +1,28 @@
+---
+layout: two-cols
+---
+
+::header::
+# How we'll achieve the objectives (high‑level)
+
+::default::
+We will introduce practical AI into five functions — Sales, Marketing, CSM, Operations, and Support — to improve day‑to‑day workflows. The approach is simple: co‑design a few high‑impact use cases per team, teach the skills to use them well, ship fast, and measure what sticks.
+
+## Program flow
+- Partner with 5 departments to surface top workflows and pain points.
+- Co‑design and prioritize 10 candidate use cases (impact × feasibility).
+- Build quick pilots, run in shadow mode, then take 5–7 live with quality gates.
+- Train and enable: AI Core for everyone + Function Labs per team; stand up AI Champions.
+- Change management: clear comms, guardrails, clinics/office hours, recognition.
+- Measure and iterate: simple weekly usage snapshots, quality sampling, funnel/support deltas, and the "can we remove it?" signal test.
+- Handoff: run books, playbooks, and a 90‑day backlog to scale wins.
+
+::right::
+## What this connects to in the deck
+- Objectives → this slide is the “how” at a glance.
+- Timeline → Phases 1–3 detail discovery, training, pilots, and go‑lives.
+- Measurement → what we track weekly to prove value and guide iteration.
+- Training & Enablement → how we build skills and sustain usage.
+- Candidate Use Cases → examples we’ll tailor with each team.
+- Change Management → practices that drive adoption (ADKAR).
+


### PR DESCRIPTION
This PR adds a concise, high‑level strategy slide to bridge from the Objectives to the Timeline, clarifying how we’ll achieve the stated goals.

What’s included
- New slide: slides/03-high-level-strategy.md (two‑column layout)
  - Summarizes the approach: partner with 5 departments, co‑design AI use cases, build quick pilots → go live, training and Champions, change management, measurement, and handoff.
  - Provides quick pointers to the deeper sections (Timeline, Measurement, Training, Use Cases, Change Management).
- Deck order updated in slides.md to insert the new slide right after 02-objectives-success-criteria.md.

Why
- Addresses the request for a “how we’ll achieve the objectives” slide that sets up the details that follow, ensuring a smooth narrative between Objectives and the Timeline.

No dependencies or build changes required. Tested locally with Slidev to verify slide renders and navigation order is correct.

Closes #49