### PR TITLE
Add more jagged peaks, highlight peak/trough quotes, and remove legend

### DIFF
--- a/components/JaggedIntelligence.vue
+++ b/components/JaggedIntelligence.vue
@@ -11,7 +11,7 @@ const props = withDefaults(
     background?: string;
   }>(),
   {
-    peaks: 8,
+    peaks: 12,
     lineColor: "#2563eb", // blue-600
     baselineColor: "#6b7280", // gray-500
     enhancedColor: "#16a34a", // green-600
@@ -85,15 +85,16 @@ function draw() {
   ctx.fillText("Human + AI (improved average)", left + 6, plusY - 12);
 
   // generate jagged points representing AI experiences
-  const n = Math.max(4, props.peaks);
+  const n = Math.max(8, props.peaks);
   const pts: [number, number][] = [];
+  const cycles = Math.max(4, Math.floor(n / 2)); // more cycles -> more highs/lows
   for (let i = 0; i <= n; i++) {
     const t = i / n;
     const x = left + (right - left) * t;
-    // sin wave base + randomness
-    const base = Math.sin(t * Math.PI * 3); // a few ups/downs
-    const noise = (Math.random() - 0.5) * 0.6;
-    const v = base * 0.9 + noise;
+    // higher-frequency sin wave + randomness for a jaggier line
+    const base = Math.sin(t * Math.PI * cycles);
+    const noise = (Math.random() - 0.5) * 0.9; // stronger noise
+    const v = base * 0.95 + noise;
     const y = midY - v * (bottom - top) * 0.45;
     pts.push([x, y]);
   }
@@ -105,12 +106,31 @@ function draw() {
     rc.line(x1, y1, x2, y2, {
       stroke: props.lineColor,
       strokeWidth: 2.5,
-      roughness: 1.2,
-      bowing: 1.5,
+      roughness: 1.3,
+      bowing: 1.6,
     });
   }
 
-  // draw markers on peaks/troughs (every other point)
+  // helper: detect local peaks and troughs
+  const locals = pts.map((p, idx) => ({ idx, x: p[0], y: p[1], type: "flat" as "peak" | "trough" | "flat" }));
+  for (let i = 1; i < pts.length - 1; i++) {
+    const yPrev = pts[i - 1][1];
+    const yCurr = pts[i][1];
+    const yNext = pts[i + 1][1];
+    // remember: smaller y is visually higher (peak)
+    if (yCurr < yPrev && yCurr < yNext) locals[i].type = "peak";
+    if (yCurr > yPrev && yCurr > yNext) locals[i].type = "trough";
+  }
+
+  const peaksOnly = locals.filter((l) => l.type === "peak");
+  const troughsOnly = locals.filter((l) => l.type === "trough");
+
+  // find the highest peak (smallest y)
+  const bestPeak = peaksOnly.sort((a, b) => a.y - b.y)[0];
+  // find a couple deepest troughs (largest y)
+  const worstTroughs = troughsOnly.sort((a, b) => b.y - a.y).slice(0, 2);
+
+  // draw small markers on alternating points for visual texture
   pts.forEach(([x, y], idx) => {
     if (idx % 2 === 0) {
       rc.circle(x, y, 6, {
@@ -120,6 +140,86 @@ function draw() {
       });
     }
   });
+
+  // utility to draw a rough circle highlight and a callout text
+  function drawCallout(
+    x: number,
+    y: number,
+    text: string,
+    options: { side?: "left" | "right"; color?: string } = {}
+  ) {
+    const side = options.side ?? (x < (left + right) / 2 ? "right" : "left");
+    const color = options.color ?? "#111827";
+
+    // circle highlight
+    rc.circle(x, y, 28, {
+      stroke: color,
+      strokeWidth: 2,
+      roughness: 1.2,
+      fill: "transparent",
+    });
+
+    // connector line
+    const dx = side === "right" ? 60 : -60;
+    const anchorX = x + dx;
+    const anchorY = y + (y < midY ? -24 : 24);
+    rc.line(x + (dx > 0 ? 14 : -14), y, anchorX, anchorY, {
+      stroke: color,
+      strokeWidth: 1.8,
+      roughness: 1,
+    });
+
+    // text
+    ctx.fillStyle = color;
+    ctx.font =
+      "13px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica Neue, Arial";
+    ctx.textBaseline = "top";
+    const tx = side === "right" ? anchorX + 8 : anchorX - 8;
+    const maxWidth = Math.min(260, right - left - 40);
+    const words = text.split(" ");
+    let line = "";
+    let ty = anchorY - 10;
+    for (let i = 0; i < words.length; i++) {
+      const test = line + (line ? " " : "") + words[i];
+      const w = ctx.measureText(test).width;
+      if (w > maxWidth && line) {
+        ctx.fillText(line, tx + (side === "right" ? 0 : -ctx.measureText(line).width), ty);
+        line = words[i];
+        ty += 16;
+      } else {
+        line = test;
+      }
+    }
+    if (line) {
+      ctx.fillText(line, tx + (side === "right" ? 0 : -ctx.measureText(line).width), ty);
+    }
+  }
+
+  // annotations: positive at a high peak
+  if (bestPeak) {
+    drawCallout(bestPeak.x, bestPeak.y, "Wow, that saved me a lot of time.", {
+      side: "right",
+      color: "#065f46", // deep green text
+    });
+  }
+
+  // annotations: negatives at deep troughs
+  if (worstTroughs[0]) {
+    drawCallout(
+      worstTroughs[0].x,
+      worstTroughs[0].y,
+      "I could have done this faster myself.",
+      { side: "left", color: "#7f1d1d" }
+    );
+  }
+  if (worstTroughs[1]) {
+    drawCallout(
+      worstTroughs[1].x,
+      worstTroughs[1].y,
+      "It didn't understand what I was trying to do.",
+      { side: "right", color: "#7f1d1d" }
+    );
+  }
 
   // title
   ctx.fillStyle = "#111827";
@@ -131,12 +231,7 @@ function draw() {
     top - 6 + 8
   );
 
-  // annotations
-  ctx.font =
-    "13px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica Neue, Arial";
-  ctx.fillStyle = "#374151";
-  ctx.fillText("Highs: great experiences", left + 8, top + 24);
-  ctx.fillText("Lows: disappointing experiences", left + 8, top + 44);
+  // Removed the small key (highs/lows) per request
 }
 
 onMounted(() => {
@@ -156,3 +251,4 @@ onBeforeUnmount(() => {
     <canvas ref="canvasRef" />
   </div>
 </template>
+

--- a/slides/18-jagged-intelligence.md
+++ b/slides/18-jagged-intelligence.md
@@ -6,4 +6,5 @@ layout: center
 
 AI capabilities are fantastic in some areas, and terrible in others, in strange ways we don't expect. This often leads to mixed experiences when using AI.
 
-<JaggedIntelligence :peaks="10" />
+<JaggedIntelligence :peaks="24" />
+


### PR DESCRIPTION
This PR updates the Jagged Intelligence diagram per the request:

- Increase jaggedness: more highs and lows by raising default peaks and using a higher-frequency base waveform with stronger noise. The slide now uses :peaks="24" for a denser, more jagged line.
- Annotate experiences: 
  - Circle and annotate the highest peak with a positive user quote (e.g., "Wow, that saved me a lot of time.").
  - Circle and annotate two deep troughs with disappointing user quotes (e.g., "I could have done this faster myself." and "It didn't understand what I was trying to do.").
- Remove the small key that labeled highs/lows, as requested.

Files changed:
- components/JaggedIntelligence.vue: logic for generating more jagged peaks, detection of peaks/troughs, callout drawing, annotations added, and legend removed.
- slides/18-jagged-intelligence.md: increased :peaks to 24 to further emphasize jaggedness.

No build or runtime behavior changes outside this slide. Let me know if you'd like different quote wording or the number of annotations adjusted.

Closes #50