### PR TITLE
Add responsive LogoGrid and embed on Young & AI section

### DIFF
--- a/components/LogoGrid.vue
+++ b/components/LogoGrid.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="logo-grid" :style="{ '--min': `${minSize}px` }">
+    <component
+      v-for="(logo, idx) in logos"
+      :is="logo.href ? 'a' : 'div'"
+      :key="idx"
+      class="logo-item"
+      :href="logo.href || undefined"
+      :target="logo.href ? '_blank' : undefined"
+      :rel="logo.href ? 'noopener' : undefined"
+      :title="logo.alt || undefined"
+    >
+      <img :src="logo.src" :alt="logo.alt || ''" loading="lazy" />
+    </component>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface LogoItem {
+  src: string
+  alt?: string
+  href?: string
+}
+
+const props = withDefaults(defineProps<{
+  logos: LogoItem[]
+  /** Minimum column width in px before wrapping to next line */
+  minSize?: number
+}>(), {
+  minSize: 80,
+})
+
+const { logos, minSize } = toRefs(props)
+</script>
+
+<style scoped>
+.logo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--min, 80px), 1fr));
+  gap: 16px;
+  align-items: center;
+}
+
+.logo-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+}
+
+.logo-item img {
+  max-width: 100%;
+  max-height: 56px;
+  height: auto;
+  object-fit: contain;
+  /* keep them subtle and consistent */
+  filter: grayscale(100%);
+  opacity: 0.9;
+  transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
+.logo-item:hover img {
+  opacity: 1;
+  filter: grayscale(0%);
+}
+
+@media (min-width: 640px) {
+  .logo-item img { max-height: 60px; }
+}
+
+@media (min-width: 1024px) {
+  .logo-item img { max-height: 72px; }
+}
+</style>
+

--- a/slides/00-introduction-ching-youngin-ai.md
+++ b/slides/00-introduction-ching-youngin-ai.md
@@ -28,3 +28,24 @@ We are a leading AI enterprise developer. We build AI solutions that ship, stick
 - Experience ranges from ML models for trend detection to automation & copilots
 - Strong focus on MLOps, data pipelines, governance, and measurable ROI
 
+#### Selected clients
+
+<LogoGrid :logos="clientLogos" :minSize="90" />
+
+<script setup lang="ts">
+const clientLogos = [
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
+  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+]
+</script>
+


### PR DESCRIPTION
Summary
- Added a reusable LogoGrid Vue component to display many partner/client logos in a responsive grid that wraps gracefully and does not overflow.
- Embedded the component in the “Young & AI” section of the introduction as a Selected clients block.

Details
- components/LogoGrid.vue
  - Props: logos (array of { src, alt, href? }), minSize (default 80px)
  - Uses CSS Grid with repeat(auto-fit, minmax(var(--min), 1fr)) to handle ~20+ logos without falling off the page.
  - Images are constrained with object-fit: contain and max-height, are grayscale by default, and de-grayscale on hover for a subtle effect.

- slides/00-introduction-ching-youngin-ai.md
  - Added a Selected clients section and used <LogoGrid :logos="clientLogos" :minSize="90" />.
  - Included sample logos using existing images in the repo. Replace or extend the clientLogos array with up to ~20 logos as needed.

Usage
To reuse elsewhere (e.g., About Us page/section), include the component and pass your logos:

```vue
<LogoGrid :logos="[
  { src: '/images/client1.png', alt: 'Client 1' },
  { src: '/images/client2.svg', alt: 'Client 2', href: 'https://client2.com' },
  // ... up to ~20
]" :minSize="90" />
```

Notes
- Slidev auto-registers components from ./components so no additional imports are required in slides.
- If you later add more logo files, just drop them into /images and update the array. The grid will adapt to any screen size.

Closes #55