### PR TITLE
Create deliverables grid layout and add grid-view strategy slide

### DIFF
--- a/layouts/deliverables-grid.vue
+++ b/layouts/deliverables-grid.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="slidev-layout deliverables-grid">
+    <div v-if="$slots.header" class="mb-4">
+      <slot name="header" />
+    </div>
+    <div class="grid-scroll">
+      <!-- 4 columns on desktop, responsive down to 3/2 on smaller viewports -->
+      <div class="grid grid-cols-4 gap-4">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style>
+.deliverables-grid {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Ensure the content never gets cut off - it scrolls within the slide if needed */
+.deliverables-grid .grid-scroll {
+  flex: 1 1 auto;
+  min-height: 0; /* allow child to shrink and enable overflow */
+  overflow-y: auto;
+}
+
+/* Make any direct children of the grid slot look like uniform cards */
+.deliverables-grid .grid > * {
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 10px;
+  padding: 12px 14px;
+  line-height: 1.3;
+}
+
+/* If authors pass a list, make list items behave like cards too */
+.deliverables-grid .grid ul,
+.deliverables-grid .grid ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: contents; /* flatten list so li become direct grid children */
+}
+.deliverables-grid .grid li {
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+@media (max-width: 1024px) {
+  .deliverables-grid .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+@media (max-width: 768px) {
+  .deliverables-grid .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>
+

--- a/slides/03-high-level-strategy.md
+++ b/slides/03-high-level-strategy.md
@@ -26,3 +26,18 @@ We will introduce practical AI into five functions — Sales, Marketing, CSM, Op
 - Candidate Use Cases → examples we’ll tailor with each team.
 - Change Management → practices that drive adoption (ADKAR).
 
+---
+layout: deliverables-grid
+---
+
+::header::
+# How we'll achieve the objectives (grid view)
+
+- Partner with 5 departments to surface top workflows and pain points.
+- Co‑design and prioritize 10 candidate use cases (impact × feasibility).
+- Build quick pilots, run in shadow mode, then take 5–7 live with quality gates.
+- Train and enable: AI Core for everyone + Function Labs per team; stand up AI Champions.
+- Change management: clear comms, guardrails, clinics/office hours, recognition.
+- Measure and iterate: simple weekly usage snapshots, quality sampling, funnel/support deltas, and the "can we remove it?" signal test.
+- Handoff: run books, playbooks, and a 90‑day backlog to scale wins.
+


### PR DESCRIPTION
Summary
- Added a new Slidev layout: deliverables-grid.vue for displaying many items (up to ~20) in a uniform, responsive grid.
- Appended a second slide to 03-high-level-strategy.md using the new layout to present the Program Flow as grid cards for side-by-side comparison with the original version.

Details
- Layout ensures content fits on a landscape slide and introduces a scrollable container so content never gets cut off at the bottom.
- Responsive behavior: 4 columns on desktop, 3/2 columns on smaller viewports.
- Works with simple Markdown lists: ul/ol are flattened so each li becomes an individual grid card automatically.

How to use
- Use `layout: deliverables-grid` in a slide frontmatter.
- Provide your items as a list or as individual child elements; each will be rendered as a card within the grid.

Why this change
- Requested a view that displays all deliverables in a grid to compare with the existing strategy slide.
- Prepared to support up to ~20 items while maintaining readability and avoiding content clipping.

Screens/visual
- No screenshots included, but the grid uses white card styling with subtle borders to match existing deck aesthetics (e.g., candidate backlog slide).

No breaking changes.

Closes #54