### PR TITLE
Redesign timeline slides and add 12‑week calendar view

### DIFF
--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -1,53 +1,176 @@
-# Timeline (12 weeks)
+# 12-Week Program Calendar (Department Sprints)
 
-## Phase 1 – Discover & Baseline (Weeks 1–2)
+Small, predictable two-week sprints per department with built-in buffer and overlap for speed and risk control.
 
-- Intake workshops per function (60–90m each) to map top workflows and pain points.
-- One 60‑minute interview per department lead (Sales, Marketing, CSM, Ops, Support) with Ching to walk through current processes, dependencies, and where AI could help; schedule at least 1 hour per department.
-- Additional stakeholder interviews as needed (≥5 total) to document current ("as‑is") business flows; synthesize notes and opportunities.
-- Instrument baselines: pull existing system metrics (funnel/CS/ops), capture current macros/templates, and define lightweight telemetry; optional pulse survey for perceived time saved. No stopwatch time studies (to reduce burden/cost).
-- Select 10 pilot candidates through facilitated impact × feasibility prioritization (no formal scorecard deliverable).
-- **Deliverable**: Pilot Backlog v1, Measurement Plan, AI Policy & Guardrails (2‑page).
+<div style="font-size: 12px; margin-bottom: 8px;">
+  Legend: <span style="font-weight:600;">I</span> = Interview (Mon, 60m) · <span style="font-weight:600;">Dev</span> = Build & prompt tuning · <span style="font-weight:600;">WS</span> = Workshop (Thu, week 2) · <span style="font-weight:600;">R</span> = Report (Fri, week 2)
+</div>
+
+<table style="width:100%; border-collapse: collapse; font-size: 14px;">
+  <thead>
+    <tr>
+      <th style="border-bottom:1px solid #ccc; text-align:left; padding:6px 8px;">Department / Stream</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W1</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W2</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W3</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W4</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W5</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W6</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W7</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W8</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W9</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W10</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W11</th>
+      <th style="border-bottom:1px solid #ccc; text-align:center; padding:6px 0;">W12</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Sales</td>
+      <td style="border-top:1px solid #eee; text-align:center;">I + Dev</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Refine · WS · R</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Catch-ups</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Discovery</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Marketing</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">I + Dev</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Refine · WS · R</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Catch-ups</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Discovery</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">CSM</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">I + Dev</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Refine · WS · R</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Operations</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">I + Dev</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Refine · WS · R</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Support</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">I + Dev</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Refine · WS · R</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Catch-up / Buffer</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Gap week · finish Sales & Marketing</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Light overlap with CSM</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Light overlap with Ops/Support</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Stabilize</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Discovery / extra builds</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+    </tr>
+    <tr>
+      <td style="border-top:1px solid #eee; padding:6px 8px; text-align:left; white-space:nowrap;">Wrap-up</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">—</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Adoption, polish</td>
+      <td style="border-top:1px solid #eee; text-align:center;">Final report</td>
+    </tr>
+  </tbody>
+</table>
+
+## Notes
+
+- Two weeks per department: Week 1 focuses on discovery and build; Week 2 on refine, workshop, and report.
+- First four weeks: two departments end-to-end (Sales → Marketing).
+- Week 5: stopgap to catch up remaining tasks from the first two departments.
+- Weeks 6–10: three departments on a staggered overlap (CSM → Ops → Support) to keep velocity while managing review cycles.
+- Remaining weeks: stabilize, adoption support, and final report.
 
 ---
 
-# Workplan & Timeline (12 weeks)
+# Department Sprint Template (2 weeks)
 
-## Phase 2 – Train & Prototype (Weeks 3–6)
+## Week 1
 
-- AI Core (2 x 90m) for all participants: prompt patterns, critique loops, verification, retrieval, and safe data use.
-- Function Labs (2 x 60m) per team with hands‑on assets (templates, checklists).
-- Build 10 pilots in 1‑week sprints (2 per function), with shadow runs in Weeks 4–5 and 3–5 going live by Week 6.
-- **Deliverable**: Friday Demos (recorded) and working prototypes; notes and usage snapshots (no template library or pilot scorecards).
+- Mon: Interview with department lead/AI Champion (60m) to walk through current workflows, systems, and improvement ideas.
+- Tue–Thu: Build workflows; fine-tune prompts; evaluate specialized AI tools for the domain; rapid shadow runs.
+- Fri: Share v1 with Champion, collect feedback, and refine.
 
----
+## Week 2
 
-# Workplan & Timeline (12 weeks)
-
-## Phase 3 – Deploy, Scale, Handoff (Weeks 7–12)
-
-- Productionize best pilots (target 5–7), add monitoring and fallback SOPs.
-- Expand to adjacent workflows; create Run Books and Champion Playbooks.
-- Share weekly usage highlights and simple reports for shipped assets (no dashboards).
-- **Deliverable**: AI Wins Digest (Weeks 8 & 12), Final Report, Roadmap for global rollout.
+- Mon–Wed: Iterate, validate, and prep enablement assets (prompts, SOPs, checklists).
+- Thu: Audience-led Workshop for the department (Q&A, feedback, usage guidance).
+- Fri: Weekly usage summary and short report (what shipped, early usage, success signals).
 
 ---
 
-# Workplan & Timeline (12 weeks)
+# Why this pacing
 
-## Optional – Long‑term usage validation (+1w, +1m, +1q)
-
-- Quick check‑ins after the 12‑week program: review usage reports and run a 2‑minute pulse survey.
-- Run a "can we remove this tool?" litmus test with Champions; track objections as a success signal.
-- Share a brief retention report and recommendations; trigger outcome‑tied bonus if sustained usage is confirmed.
-
+- Focus: Dedicated two-week windows per department drive clarity and speed.
+- Feedback cadence: Interview on Day 1, share by end of Week 1, workshop on Thu Week 2, report Fri ensures learning loops.
+- Risk control: A gap week at Week 5 and discovery/buffer in Week 10 absorb surprises without slipping milestones.
+- Scale: Staggered overlap in Weeks 6–10 allows 3 departments to progress concurrently without overwhelming reviewers.
 
 ---
 
-# Workplan & Timeline (12 weeks)
+# Key dates and artifacts
 
-## Cadence
-
-- Weekly: Mon planning (30m), Tue/Thu build, Fri demo (30–45m).
-- Biweekly: Champion Clinic (90m), adoption/metrics review (30m).
-- Monthly: Exec Readout (30m).
+- Interview: Monday of each sprint Week 1 (60m).
+- Workshop: Thursday of each sprint Week 2 (audience-led, Q&A, adoption blockers).
+- Report: Friday of each sprint Week 2 (brief, metrics snapshot, next steps).
+- Artifacts: Prompts, workflows, SOPs, Champion notes, short weekly report, final program report.


### PR DESCRIPTION
This PR restructures the Timeline slides to match the desired 12‑week, department‑focused sprint model and adds a clear calendar view of the entire program.

What’s included
- New first slide: 12‑Week Program Calendar with weeks 1–12 across the top and rows for each department (Sales, Marketing, CSM, Operations, Support), plus Catch‑up/Buffer and Wrap‑up.
- Visual markers and legend for key events: Interview (Mon), Workshop (Thu week 2), and Report (Fri week 2).
- Staggered overlap plan for weeks 6–10 to run 3 departments concurrently while maintaining feedback cadence.
- Built‑in stopgap Week 5 and additional discovery/buffer time in Week 10.
- Follow‑up slides detailing the 2‑week sprint template (day‑by‑day), rationale for pacing, and the key dates/artifacts.

Why
- Aligns the slide content with the proposed approach: ~2 weeks per department, explicit key touchpoints, and program‑level buffer.
- Makes the plan easy to grasp at a glance with a calendar, then explains the reasoning and structure on subsequent slides.

Files changed
- slides/05-workplan-timeline.md: Rewrote content to include the calendar and detailed sprint breakdown.

Notes
- Existing Communications slide (slides/11-communications.md) remains unchanged; the new calendar is specific to the Timeline section per the request.

Closes #64