### PR TITLE
Add partner company logos to Young & AI About section

### DIFF
--- a/slides/00-introduction-ching-youngin-ai.md
+++ b/slides/00-introduction-ching-youngin-ai.md
@@ -35,18 +35,20 @@ We are a leading AI enterprise developer. We build AI solutions that ship, stick
 
 <script setup lang="ts">
 const clientLogos = [
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
-  { src: '/images/Logo-Horizons-Dark-Transparent-2-1.png', alt: 'Horizons' },
-  { src: '/images/young--ai-high-resolution-logo-transparent.png', alt: 'Young & AI' },
+  // Note: exclude Young & AI and Horizons per request
+  { src: '/images/logos/bmw.svg', alt: 'BMW' },
+  { src: '/images/logos/siemens-logo-0-2048x2048-1.png', alt: 'Siemens' },
+  { src: '/images/logos/pingan-bilingual-logo-vertical-2022.png', alt: 'Ping An' },
+  { src: '/images/logos/Standard_Chartered_(2021).svg.png', alt: 'Standard Chartered' },
+  { src: '/images/logos/Coutts_old.svg', alt: 'Coutts' },
+  { src: '/images/logos/SAIC-Motor-Logo-2011.png', alt: 'SAIC Motor' },
+  { src: '/images/logos/SiM-logo-png.png.webp', alt: 'SIM' },
+  // Repeat a few to reach 10+ and visualize spacing
+  { src: '/images/logos/bmw.svg', alt: 'BMW' },
+  { src: '/images/logos/siemens-logo-0-2048x2048-1.png', alt: 'Siemens' },
+  { src: '/images/logos/Standard_Chartered_(2021).svg.png', alt: 'Standard Chartered' },
+  { src: '/images/logos/pingan-bilingual-logo-vertical-2022.png', alt: 'Ping An' },
+  { src: '/images/logos/Coutts_old.svg', alt: 'Coutts' },
 ]
 </script>
 


### PR DESCRIPTION
This PR updates the Selected clients section on the Young & AI about slide to showcase partner/company logos we’ve previously worked with.

What changed
- Replaced placeholder Young & AI and Horizons logos with real partner logos using the existing LogoGrid component.
- Excluded Young & AI and Horizons logos per the request.
- Repeated a few to ensure we have 10+ entries so spacing/layout can be reviewed.

Logos used (web-friendly formats only)
- BMW (svg)
- Siemens (png)
- Ping An (png)
- Standard Chartered (png)
- Coutts (svg)
- SAIC Motor (png)
- SIM (webp)

Notes
- EPS/AI assets (e.g., Commonwealth Bank, DBS, PwC) were not included as browsers don’t render those formats directly. If desired, we can convert them to SVG/PNG and include them in a follow-up.
- Layout uses the existing LogoGrid with minSize=90 for consistent sizing.

Preview
- Slide file: slides/00-introduction-ching-youngin-ai.md
- Component: components/LogoGrid.vue

Let me know if you’d like different selections, order, or sizing.

Closes #75