### PR TITLE
Add table of contents with three main slide sections

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -17,6 +17,10 @@ For internal discussion only
 </div>
 
 ---
+src: ./slides/00-table-of-contents.md
+---
+
+---
 src: ./slides/01-executive-summary.md
 ---
 

--- a/slides/00-table-of-contents.md
+++ b/slides/00-table-of-contents.md
@@ -1,0 +1,38 @@
+---
+layout: center
+---
+
+# Table of Contents
+
+Select a section to jump there
+
+<div class="grid grid-cols-3 gap-6 mt-8 text-left max-w-140 mx-auto">
+  <a href="#/3" @click.prevent="$slidev.nav.go(3)" class="block p-5 rounded-lg border bg-white/80 hover:bg-white shadow-sm">
+    <div class="text-sm uppercase tracking-wide opacity-70">Section 1</div>
+    <div class="text-xl font-semibold mt-1">Objectives & Approach</div>
+    <ul class="list-disc list-inside text-sm mt-3 opacity-85">
+      <li>Why this now, what good looks like</li>
+      <li>How we’ll achieve it (strategy)</li>
+    </ul>
+  </a>
+
+  <a href="#/9" @click.prevent="$slidev.nav.go(9)" class="block p-5 rounded-lg border bg-white/80 hover:bg-white shadow-sm">
+    <div class="text-sm uppercase tracking-wide opacity-70">Section 2</div>
+    <div class="text-xl font-semibold mt-1">Plan & Delivery</div>
+    <ul class="list-disc list-inside text-sm mt-3 opacity-85">
+      <li>Timeline and ways of working</li>
+      <li>Measurement, training, and use cases</li>
+      <li>Governance, communications, reporting</li>
+    </ul>
+  </a>
+
+  <a href="#/22" @click.prevent="$slidev.nav.go(22)" class="block p-5 rounded-lg border bg-white/80 hover:bg-white shadow-sm">
+    <div class="text-sm uppercase tracking-wide opacity-70">Section 3</div>
+    <div class="text-xl font-semibold mt-1">Proposal & Commercials</div>
+    <ul class="list-disc list-inside text-sm mt-3 opacity-85">
+      <li>Packages and pricing</li>
+      <li>Optional long‑term usage checks</li>
+    </ul>
+  </a>
+</div>
+


### PR DESCRIPTION
Summary
- Added a new Table of Contents slide after the title page to make the deck easier to navigate.
- Grouped content into three clear sections that match the proposal flow:
  1. Objectives & Approach
  2. Plan & Delivery
  3. Proposal & Commercials
- Each item in the TOC links to the first slide of the respective section and also includes a click handler fallback to ensure navigation works in presenter mode.

Details
- New file: slides/00-table-of-contents.md
  - Centered layout with three cards for the sections.
  - Links use both href anchors (e.g. `#/9`) and `@click.prevent="$slidev.nav.go(9)"` so it works across build and dev.
- Updated slides.md to import the new TOC right after the title slide.

Notes
- The TOC does not list every slide, per the request; it simply jumps to the start of each major section.
- Section start targets:
  - Objectives & Approach → Executive Summary (slide 3 after adding the TOC)
  - Plan & Delivery → Workplan Timeline (first slide of that section)
  - Proposal & Commercials → Effort & Commercials

If you plan to rearrange slides later, we can update the jump targets (numbers) or switch to named routes once the structure stabilizes.

Closes #90