### PR TITLE
Use Horizons accent color for Executive Summary highlights

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,6 +53,16 @@
 }
 
 /* Optional: subtle highlighter effect */
+/* Ensure any element with `.highlight` uses the Horizons accent */
+.highlight {
+  background: linear-gradient(
+    to bottom,
+    transparent 60%,
+    rgba(var(--horizon-accent-rgb), 0.22) 0
+  );
+  border-radius: 2px;
+}
+
 .keyword.highlight,
 .emph.highlight {
   background: linear-gradient(
@@ -187,3 +197,4 @@
   border-radius: 9999px;
   box-shadow: 0 6px 16px rgba(var(--horizon-accent-rgb), 0.25);
 }
+

--- a/styles.css
+++ b/styles.css
@@ -28,7 +28,7 @@
 /* Thematic color helpers */
 :root {
   /* Primary accent used across custom elements */
-  --horizon-accent: #113c4e; /* blue-600 */
+  --horizon-accent: #113c4e;
   --horizon-accent-rgb: 17, 60, 78;
 
   /* ADKAR palette */


### PR DESCRIPTION
Summary
- Ensures highlighted text in the Executive Summary (and anywhere else using the `.highlight` utility) uses the Horizons brand accent color defined in styles.css.

What changed
- Added a generic `.highlight` class in styles.css that applies a subtle underline-style background using `var(--horizon-accent-rgb)`. This aligns the highlight effect with the brand color, not a default yellow or other color.
- Kept existing `.keyword` / `.emph` accent styles, and ensured `.keyword.highlight` and `.emph.highlight` continue to work the same.

Why
- The Executive Summary uses `<span class="keyword highlight">` for emphasis. This change guarantees the background highlight tint is driven by the Horizons accent variable for brand consistency.

Testing
- Open the deck and view slide "01-executive-summary". The highlighted "12‑week" text now shows the brand-colored highlight tint.

Notes
- If future slides use `.highlight` without `.keyword`/`.emph`, they will still get the brand-aligned highlight background.


Closes #100