### PR TITLE
Add Table of Contents with three main sections and deep links

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -17,6 +17,10 @@ For internal discussion only
 </div>
 
 ---
+src: ./slides/00-table-of-contents.md
+---
+
+---
 src: ./slides/01-executive-summary.md
 ---
 

--- a/slides/00-table-of-contents.md
+++ b/slides/00-table-of-contents.md
@@ -1,0 +1,21 @@
+---
+layout: center
+class: text-center
+---
+
+# Table of Contents
+
+Three parts to this proposal:
+
+- Objectives & Strategy — why this matters, what we aim to achieve, and where we focus.
+  
+  [Go to this section](/#/objectives)
+
+- Plan & Execution — 12-week workplan, sprints, and example workflows.
+  
+  [Go to this section](/#/plan)
+
+- Commercial Proposal — packages, scope, and commercials.
+  
+  [Go to this section](/#/commercials)
+

--- a/slides/02-objectives-success-criteria.md
+++ b/slides/02-objectives-success-criteria.md
@@ -1,6 +1,7 @@
 ---
 layout: three-cols
 transition: fade
+route: /objectives
 ---
 
 ::header::

--- a/slides/05-workplan-timeline.md
+++ b/slides/05-workplan-timeline.md
@@ -1,3 +1,7 @@
+---
+route: /plan
+---
+
 # We'll build AI workflows for each department in 2-week sprints with time for follow-on review
 
 Every sprint includes "as-is" process flow interviews, AI workflow build and validate, trial period, workshops, and sprint review.

--- a/slides/14-effort-commercials.md
+++ b/slides/14-effort-commercials.md
@@ -1,5 +1,6 @@
 ---
 layout: three-cols
+route: /commercials
 ---
 
 ::header::


### PR DESCRIPTION
Summary
- Added a dedicated Table of Contents slide immediately after the cover to improve navigation.
- Introduced stable deep links to three main sections using Slidev routes.

What changed
1) New slide: slides/00-table-of-contents.md
   - Presents the three major sections and links to them:
     - Objectives & Strategy → /#/objectives
     - Plan & Execution → /#/plan
     - Commercial Proposal → /#/commercials

2) Section routes added to the first slide of each section for robust linking:
   - slides/02-objectives-success-criteria.md → route: /objectives
   - slides/05-workplan-timeline.md → route: /plan
   - slides/14-effort-commercials.md → route: /commercials

3) slides.md updated to insert the TOC right after the title slide.

Why this approach
- Using Slidev route anchors avoids fragile slide-number links and remains stable if slides are reordered or added.
- The TOC intentionally keeps to three top-level areas as requested and doesn’t list every slide.

Notes
- If you prefer different group names (e.g., “Why / How / Investment”) or want section divider slides, I can add them in a follow-up.
- If you’d like the TOC to be visually richer (e.g., 3 clickable cards), happy to iterate.

Closes #90