### PR TITLE
Add budget requirement for off-the-shelf tool testing

### DIFF
--- a/slides/04-operating-model-roles.md
+++ b/slides/04-operating-model-roles.md
@@ -5,4 +5,5 @@
 - AI Consultant: Ching — designs curriculum, runs discovery, builds pilots, defines metrics, and hosts Friday demos.
 - Functional Leads — one per department (Sales, Marketing, CSM, Ops, Support) serving as AI Champions; provide processes, sample data, and sign‑off, and commit to a 60‑minute discovery interview with Ching in Weeks 1–2.
 - IT / Data / Legal — provision tools and access (SSO), review data policy and retention, ensure compliance.
+- Tool evaluation budget — allocate approximately $500 USD (≈¥3,500 RMB) for 1–2 months of trials across 10+ off‑the‑shelf SaaS tools (most ≈$20/month) so we can subscribe, test, and compare during pilots.
 


### PR DESCRIPTION
This PR adds the requested budget requirement to the slide deck.

- Location: slides/04-operating-model-roles.md (Operating Model & Required Resources)
- Change: Adds a new bullet under "Required resources" specifying a small tool evaluation budget of approximately $500 USD (≈¥3,500 RMB) to cover 1–2 months of trials across 10+ off‑the‑shelf SaaS tools (~$20/month each). This ensures we can subscribe, test, and compare solutions during pilot builds.

Rationale: This requirement fits naturally under "Required resources" as it is a client-provided enabler for the program. It keeps the commercials slide focused on package pricing while capturing this operational need as an assumption/resource.

Closes #111