### PR TITLE
Align Required Resources slide with timeline and add to deck

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -34,6 +34,10 @@ src: ./slides/03-high-level-strategy.md
 ---
 
 ---
+src: ./slides/04-operating-model-roles.md
+---
+
+---
 src: ./slides/05-workplan-timeline.md
 ---
 

--- a/slides.md
+++ b/slides.md
@@ -33,9 +33,7 @@ src: ./slides/02-objectives-success-criteria.md
 src: ./slides/03-high-level-strategy.md
 ---
 
----
-src: ./slides/04-operating-model-roles.md
----
+
 
 ---
 src: ./slides/05-workplan-timeline.md
@@ -43,6 +41,10 @@ src: ./slides/05-workplan-timeline.md
 
 ---
 src: ./slides/sprint-breakdown.md
+---
+
+---
+src: ./slides/04-operating-model-roles.md
 ---
 
 ---

--- a/slides/04-operating-model-roles.md
+++ b/slides/04-operating-model-roles.md
@@ -1,19 +1,24 @@
-# Operating Model & Required Resources
+---
+layout: two-cols
+---
 
-## How we work (aligned to the 2-week sprint and 12-week timeline)
+::header::
+# We optimize stakeholder commitments and resource usage to maximize the impact of this project
 
-- Cadence — Department-by-department, 2-week sprints: Week 1 (interview, build/validate), Week 2 (share, workshop, report), optional Week 3 follow-on review. Program reviews at Weeks 5 and 12.
-- Communications — Weekly report on Fridays from Ching; end-of-month executive updates (Weeks 4/8/12).
+::default::
 
-## Required resources and time commitments
+## Stakeholder commitments
 
-- Young & AI (Ching) — runs interviews, builds and validates workflows, hosts workshops, sends weekly reports, leads program reviews.
-- AI Champion (per department) —
-  - 60 minutes for interview (Week 1)
-  - Async feedback during build/validate (Week 1–2)
-  - Join workshop (Week 2)
-  - Review weekly report and confirm next steps (Week 2, Fri)
-- Whole department team — participate in the share-with-team session and the workshop in Week 2; provide feedback on adoption blockers.
-- Project sponsor — review weekly reports; attend end-of-month executive updates (Weeks 4/8/12); join program review checkpoints (Weeks 5 and 12). Optional attendance at department workshops and interviews.
-- IT / Data / Legal — provision tool access (SSO), data connections, and policy approvals in Weeks 1–2; ongoing guidance on compliance and retention.
+- **Young & AI** — conducts interviews, builds and validates AI workflows, hosts workshops, shares reports, leads program reviews.
+- **AI Champion** (per department)
+  - "As-is" process flow interview (1 hour)
+  - Async feedback during build/validate (~2 hours/week)
+  - Join workshop (1 hour)
+  - Review report and confirm next steps (1 hour)
+- **Whole department team** — participate in the share-with-team session and the workshop in Week 2; provide feedback on adoption blockers (~3 hours / sprint).
+- **Project sponsor** — reviews reports; join program review checkpoints (Weeks 5 and 12). Optional attendance at department workshops and interviews (~10 hours / project).
 
+::right::
+## Other requirements
+- **IT / Data / Legal** — provision tool access (SSO), data connections, and policy approvals in Weeks 1–2; ongoing guidance on compliance and retention.
+- **Tool budget** - allocate approximately $500 USD (~¥3,500 RMB) for tool evaluation and workflow development. 

--- a/slides/04-operating-model-roles.md
+++ b/slides/04-operating-model-roles.md
@@ -1,8 +1,19 @@
 # Operating Model & Required Resources
 
-## Required resources
+## How we work (aligned to the 2-week sprint and 12-week timeline)
 
-- AI Consultant: Ching — designs curriculum, runs discovery, builds pilots, defines metrics, and hosts Friday demos.
-- Functional Leads — one per department (Sales, Marketing, CSM, Ops, Support) serving as AI Champions; provide processes, sample data, and sign‑off, and commit to a 60‑minute discovery interview with Ching in Weeks 1–2.
-- IT / Data / Legal — provision tools and access (SSO), review data policy and retention, ensure compliance.
+- Cadence — Department-by-department, 2-week sprints: Week 1 (interview, build/validate), Week 2 (share, workshop, report), optional Week 3 follow-on review. Program reviews at Weeks 5 and 12.
+- Communications — Weekly report on Fridays from Ching; end-of-month executive updates (Weeks 4/8/12).
+
+## Required resources and time commitments
+
+- Young & AI (Ching) — runs interviews, builds and validates workflows, hosts workshops, sends weekly reports, leads program reviews.
+- AI Champion (per department) —
+  - 60 minutes for interview (Week 1)
+  - Async feedback during build/validate (Week 1–2)
+  - Join workshop (Week 2)
+  - Review weekly report and confirm next steps (Week 2, Fri)
+- Whole department team — participate in the share-with-team session and the workshop in Week 2; provide feedback on adoption blockers.
+- Project sponsor — review weekly reports; attend end-of-month executive updates (Weeks 4/8/12); join program review checkpoints (Weeks 5 and 12). Optional attendance at department workshops and interviews.
+- IT / Data / Legal — provision tool access (SSO), data connections, and policy approvals in Weeks 1–2; ongoing guidance on compliance and retention.
 


### PR DESCRIPTION
This PR updates the Required Resources slide and ensures it is placed in the right position in the proposal deck.

Key changes:
- Rewrote slides/04-operating-model-roles.md to align with the detailed sprint breakdown and 12-week timeline, explicitly calling out roles: Young & AI (Ching), AI Champion, Whole department team, Project sponsor, and IT/Data/Legal, along with their touchpoints (interview, build/validate, share, workshop, report, program reviews at Weeks 5 & 12, and executive updates at Weeks 4/8/12).
- Added the Operating Model & Required Resources slide into slides.md immediately after the high-level strategy and before the workplan timeline so readers understand roles and commitments before viewing the timeline.

Rationale:
- Keeps the resources/roles slide consistent with the weekly cadence shown in the timeline and sprint breakdown.
- Provides clear time commitments and expectations for each stakeholder group.
- Placement before the timeline improves flow and context for the reader.

No build config or dependencies were changed.

Closes #114